### PR TITLE
fix: graph keep re-index when loading

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -43,8 +43,8 @@ on:
         type: boolean
         required: true
         default: true
-  schedule: # Every workday at the 2 P.M. (UTC) we run a scheduled nightly build
-    - cron: '0 14 * * MON-FRI'
+  # schedule: # Every workday at the 2 P.M. (UTC) we run a scheduled nightly build
+  #   - cron: '0 14 * * MON-FRI'
 
 env:
   CLOJURE_VERSION: '1.11.1.1413'

--- a/src/electron/electron/fs_watcher.cljs
+++ b/src/electron/electron/fs_watcher.cljs
@@ -52,7 +52,7 @@
                   (utils/read-file path))
         stat (when (and (not= event "unlink")
                         (not dir-path?))
-               (fs/statSync path))]
+               (utils/fs-stat->clj path))]
     (send-file-watcher! dir event (merge {:dir (utils/fix-win-path! dir)
                                           :path (utils/fix-win-path! path)
                                           :content content

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -123,7 +123,7 @@
       (when (and (chmod-enabled?) (fs/existsSync path) (not (writable? path)))
         (fs/chmodSync path "644"))
       (fs/writeFileSync path content)
-      (fs/statSync path)
+      (utils/fs-stat->clj path)
       (catch :default e
         (logger/warn ::write-file path e)
         (let [backup-path (try
@@ -144,7 +144,7 @@
   (fs/renameSync old-path new-path))
 
 (defmethod handle :stat [_window [_ path]]
-  (fs/statSync path))
+  (utils/fs-stat->clj path))
 
 (defn- get-files
   "Returns vec of file-objs"
@@ -505,7 +505,6 @@
 (defmethod handle :setGitAutoCommit []
   (debounced-configure-auto-commit!)
   nil)
-
 
 (defmethod handle :installMarketPlugin [_ [_ mft]]
   (plugin/install-or-update! mft))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -149,7 +149,6 @@
         (logger/warn "Unknown PAC rule:" line)
         nil))))
 
-
 (defn <get-system-proxy
   "Get system proxy for url, requires proxy to be set to system"
   ([] (<get-system-proxy "https://www.google.com"))
@@ -288,3 +287,10 @@
     (catch :default _
       (println "decodeURIComponent failed: " uri)
       uri)))
+
+(defn fs-stat->clj
+  [path]
+  (let [stat (fs/statSync path)]
+    {:size (.-size stat)
+     :mtime (.-mtime stat)
+     :ctime (.-ctime stat)}))


### PR DESCRIPTION
The reason is that `mtime` and `ctime` are lost in the main thread.